### PR TITLE
URLEncode cookie values

### DIFF
--- a/src/main/scala/com/gu/featureswitching/CookieFeatureSwitchingOverrideStrategy.scala
+++ b/src/main/scala/com/gu/featureswitching/CookieFeatureSwitchingOverrideStrategy.scala
@@ -1,6 +1,7 @@
 package com.gu.featureswitching
 
 import org.scalatra._
+import java.net.{URLDecoder, URLEncoder}
 
 trait CookieFeatureSwitchingOverrideStrategy extends FeatureSwitchingOverrideStrategy
     with ScalatraKernel with CookieSupport {
@@ -9,14 +10,18 @@ trait CookieFeatureSwitchingOverrideStrategy extends FeatureSwitchingOverrideStr
 
   // TODO: clear obsolete keys for non-existing features, by reading the list of existing switches
   private def rawValue = cookies.get(featureSwitchOverrideKey).getOrElse("")
+  private def rawCookie = URLDecoder.decode(rawValue, "utf-8")
 
-  private def cookieMap = rawValue.split(",").map(_.split("=").toList).flatMap {
+  private def cookieMap = rawCookie.split(",").map(_.split("=").toList).flatMap {
     case List(key, "true") => Some((key -> true))
     case List(key, "false") => Some((key -> false))
     case _ => None // invalid token, ignore
   }.toMap
 
-  private def renderCookie(newCookieMap: Map[String, Boolean]) = newCookieMap.map {
+  private def renderCookie(newCookieMap: Map[String, Boolean]) =
+    URLEncoder.encode(renderCookieString(newCookieMap), "utf-8")
+
+  private def renderCookieString(newCookieMap: Map[String, Boolean]) = newCookieMap.map {
     case (key, value) => "%s=%s".format(key, value)
   }.toList.mkString(",")
 


### PR DESCRIPTION
Otherwise the syntax makes the cookie unreadable, preventing enabling multiple features.

I naively thought the scalatra cookies were encoded by default. I was wrong.
