### PR TITLE
Update: Scala: Bump to 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version in ThisBuild := "0.13-SNAPSHOT"
 
 organization in ThisBuild := "com.gu"
 
-scalaVersion in ThisBuild := "2.10.0"
+scalaVersion in ThisBuild := "2.11.6"
 
 libraryDependencies ++= Common.dependencies
 

--- a/scalatra/build.sbt
+++ b/scalatra/build.sbt
@@ -1,8 +1,8 @@
 name := "feature-switching-scalatra"
 
 lazy val scalatraDependencies = Seq(
-  "net.liftweb" %% "lift-json" % "2.5",
-  "org.scalatra" %% "scalatra" % "2.0.5"
+  "net.liftweb" %% "lift-json" % "2.6.2",
+  "org.scalatra" %% "scalatra" % "2.3.0"
 )
 
 libraryDependencies ++= Common.dependencies

--- a/scalatra/src/main/scala/com/gu/featureswitching/FeatureSwitchDispatcher.scala
+++ b/scalatra/src/main/scala/com/gu/featureswitching/FeatureSwitchDispatcher.scala
@@ -29,7 +29,7 @@ trait FeatureSwitchDispatcher extends ScalatraServlet
   }
 
   def noContent = {
-    status(201)
+    status_=(201)
   }
 
   def featureResponse(feature: FeatureSwitch): FeatureSwitchResponse = {

--- a/scalatra/src/main/scala/com/gu/featureswitching/ScalatraCookieFeatureSwitchingOverrideStrategy.scala
+++ b/scalatra/src/main/scala/com/gu/featureswitching/ScalatraCookieFeatureSwitchingOverrideStrategy.scala
@@ -3,7 +3,7 @@ package com.gu.featureswitching
 import org.scalatra._
 
 trait ScalatraCookieFeatureSwitchingOverrideStrategy extends
-    CookieFeatureSwitchingOverrideStrategy with ScalatraKernel with CookieSupport {
+    CookieFeatureSwitchingOverrideStrategy with ScalatraBase {
 
   def getCookie(name: String) = cookies.get(name)
   def setCookies(name: String, value: String) = cookies.set(name, value)


### PR DESCRIPTION
This updates the library to 2.11 and brings the dependencies into line and removes depreciation warnings resulting from the bumps. Addresses #9 

I discussed how to do this with @sihil and we've agreed that this upgrade will also be a semvar major update to allow further 2.10 updates if needed.