### PR TITLE
Maven: add configuration to release to MVN central

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,6 @@ sonatypeSettings
 
 name in ThisBuild := "feature-switching"
 
-version in ThisBuild := "1.0-SNAPSHOT"
-
 organization in ThisBuild := "com.gu"
 
 scalaVersion in ThisBuild := "2.11.6"
@@ -42,10 +40,7 @@ ReleaseKeys.releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(
-    action = state => Project.extract(state).runTask(PgpKeys.publishSigned, state)._1,
-    enableCrossBuild = true
-  ),
+  ReleaseStep(action = state => Project.extract(state).runTask(PgpKeys.publishSigned, state)._1),
   setNextVersion,
   commitNextVersion,
   ReleaseStep(state => Project.extract(state).runTask(SonatypeKeys.sonatypeReleaseAll, state)._1),

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,1 +1,3 @@
 name := "feature-switching-core"
+
+publishArtifact := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.2")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")

--- a/scalatra/build.sbt
+++ b/scalatra/build.sbt
@@ -1,5 +1,7 @@
 name := "feature-switching-scalatra"
 
+publishArtifact := true
+
 lazy val scalatraDependencies = Seq(
   "net.liftweb" %% "lift-json" % "2.6.2",
   "org.scalatra" %% "scalatra" % "2.3.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,2 @@
+version in ThisBuild := "1.0-SNAPSHOT"
+


### PR DESCRIPTION
This copies other projects that are publishing to Maven and tries to create the same config in the feature switching library.