### PR TITLE
Fix typo in Scalatra adapter

### DIFF
--- a/scalatra/src/main/scala/com/gu/featureswitching/ScalatraCookieFeatureSwitchingOverrideStrategy.scala
+++ b/scalatra/src/main/scala/com/gu/featureswitching/ScalatraCookieFeatureSwitchingOverrideStrategy.scala
@@ -6,6 +6,6 @@ trait ScalatraCookieFeatureSwitchingOverrideStrategy extends
     CookieFeatureSwitchingOverrideStrategy with ScalatraBase {
 
   def getCookie(name: String) = cookies.get(name)
-  def setCookies(name: String, value: String) = cookies.set(name, value)
+  def setCookie(name: String, value: String) = cookies.set(name, value)
 
 }


### PR DESCRIPTION
This fixes an issue I bumped into when moving flex over to this. Pretty sure this was never used which is why it's only just been spotted.